### PR TITLE
Hotfix/uses env file to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+COMPOSE_PROJECT_NAME=FIGMA_LINUX_FONT_HELPER
+#FONT_FOLDER=/home/my-user/.local/share/fonts

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ This project was a reverse engineer from the local font helper from Figma for Ap
 You can also use `docker-compose` in order to run it as a container, simply run `docker-compose up` and let docker do it's magic
 
 There's also a environment variable in the compose file, called `FONTS_FOLDER`, use this variable if your font folder is mapped somewhere else, for example, on OSX you might want to use `FONT_FOLDER=~/Library/Fonts docker-compose up`
+
+Rename `.env.example` to `.env` to define a custom value to `FONTS_FOLDER` before build your containers with `docker-compose`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 services:
   server:
     build: .


### PR DESCRIPTION
A small improvement to use env files with docker-compose to define docker project name and an custom value to FONT_FOLDER. Also update docker-compose.yml file to the latest version